### PR TITLE
Refactor for reusability

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Download All Dashboards",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/cmd/dd-tf",
+            "args": [
+                "dashboards",
+                "download",
+                "--all"
+            ],
+            "envFile": "${workspaceFolder}/.env",
+            "showLog": false,
+            "trace": "verbose"
+        }
+    ]
+}

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ lint: go-lint ## Lint code
 
 .PHONY: test
 test: ## Runs go tests
-	@go test -v ./...	
+	@go test ./...	
 
 .PHONY: build
 build: ## Builds the go binary

--- a/README.md
+++ b/README.md
@@ -3,202 +3,33 @@
 [![CI](https://github.com/AD7six/dd-tf/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/AD7six/dd-tf/actions/workflows/ci.yml)
 [![AIL 2](https://img.shields.io/badge/AIL-2-blue)](https://danielmiessler.com/blog/ai-influence-level-ail)
 
-Datadog ⇄ Terraform helper CLI.
+Datadog ⇄ Terraform helper CLI. Download dashboards and monitors as JSON for version control and Terraform.
 
-Functionality useful for managing Datadog resources as JSON files.
+Status: works — Expect sharp edges though, contributions welcome 🙂.
 
-Status: works - Expect sharp edges though, contributions welcome 🙂.
+## Quick start
 
-## Why
-
-If you're managing your Datadog account config entirely in the UI you've likely
-hit problems such as things being changed (unintentionally) by colleagues. How
-can you see what has changed, and if necessary restore an earlier version?
-
-That's the general context for this cli, with dashboards being the start point.
-
-## What it does
-
-* Downloads Datadog dashboards filtered by ID, team tag or all of them using
-  Datadog's API.
-* Writes JSON files for each dashboard to a path of your choice.
-
-It does not push changes back to Datadog; the intent is to use Terraform is the
-source of truth for restoring state when necessary.
-
-## Install
-
-Prerequisites: Go 1.21+
-
-* From source (recommended during development):
+Install:
 
 ```bash
-make build
+make build  # or: go install github.com/AD7six/dd-tf/cmd/dd-tf@latest
 ```
 
-Binary will be created at `bin/dd-tf`.
+Configure `.env` with `DD_API_KEY` and `DD_APP_KEY` (and optionally `DD_SITE`).
 
-* Or install directly with Go:
+Common commands:
 
 ```bash
-go install github.com/AD7six/dd-tf/cmd/dd-tf@latest
-```
-
-## Configure
-
-The CLI reads environment variables and also supports a local `.env` file (loaded via `godotenv`).
-
-Minimum required:
-
-* `DD_API_KEY` – your Datadog API key
-* `DD_APP_KEY` – your Datadog application key
-
-Optional:
-
-* `DD_SITE` – Datadog [site parameter](https://docs.datadoghq.com/getting_started/site/) (default: `datadoghq.com`)
-* `DASHBOARDS_DIR` – base folder for dashboard files (default: `data/dashboards`)
-* `DASHBOARDS_PATH_TEMPLATE` – full path pattern (default: `{DASHBOARDS_DIR}/{id}.json`)
-* `HTTP_TIMEOUT` – HTTP client timeout in seconds (default: `60`)
-
-Create a `.env` file in your repo root:
-
-```dotenv
-DD_API_KEY=your_api_key
-DD_APP_KEY=your_app_key
-# DD_SITE=datadoghq.eu  # or us3.datadoghq.com, etc. (without 'api.' prefix)
-# DASHBOARDS_DIR=data/dashboards
-# DASHBOARDS_PATH_TEMPLATE={DASHBOARDS_DIR}/{team}/{title}-{id}.json
-# HTTP_TIMEOUT=60
-```
-
-### Path templating
-
-By default, dashboard files are created in `data/dashboards/{id}.json`.
-
-This can be overridden via cli arguments:
-
-```
-dd-tf dashboards download --all --output='/somewhere/else/{id}-{title}.json'
-```
-
-Or by setting `DASHBOARDS_DIR` or `DASHBOARDS_PATH_TEMPLATE` environment
-variables. Literal strings can of course be used, additionally the following
-placeholders are supported:
-
-* `{DASHBOARDS_DIR}`
-* `{id}`
-* `{title}`
-* `{team}`
-* `{anyTagKey}`
-
-Examples:
-
-* Group by team, include title: `{DASHBOARDS_DIR}/{team}/{title}-{id}.json`
-* Flat layout by ID only: `{DASHBOARDS_DIR}/{id}.json`
-
-Titles and tag values are sanitized for safe filenames (non-alphanumerics →
-`-`). Missing tags render as "none".
-
-## Usage
-
-List commands:
-
-```bash
-bin/dd-tf --help
-bin/dd-tf dashboards --help
-bin/dd-tf dashboards download --help
-```
-
-Common flows:
-
-1) Pull specific dashboards by ID (comma-separated):
-
-```bash
-# ID is visible in the Datadog URL: https://app.datadoghq.com/dash/<id>
-bin/dd-tf dashboards download --id=f6z-bm3-amx,3ir-qw8-ccn
-```
-
-2) Refresh all dashboards currently tracked in the dashboards dir (re-download
-   by scanning existing JSON files for their `id`):
-
-```bash
-bin/dd-tf dashboards download --update
-```
-
-3) Download all dashboards from your Datadog account:
-
-```bash
+# Dashboards
 bin/dd-tf dashboards download --all
+bin/dd-tf dashboards download --id=abc-def-ghi
 ```
 
-4) Download team dashboards:
+## Documentation
 
-```bash
-bin/dd-tf dashboards download --team=platform
-```
-
-## End-to-end workflow
-
-### UI → file → Terraform
-
-_See the `./terraform` folder for an example, functional, terraform project._
-
-1. Make your changes in the Datadog UI.
-2. Download/update the json files to your terraform project:
-     - For one dashboard: `dd-tf dashboards download --id=<id>`
-     - For all dashboards: `dd-tf dashboards download --all`
-     - To refresh all existing tracked dashboards to match current state: `dd-tf dashboards download --update`
-3. Commit the resulting JSON files.
-4. Reference the JSON in Terraform using the Datadog provider - see
-   `./terraform` project for details.
-
-### Drift/unwanted change → revert
-
-Unwanted changes to something? Re-apply your last committed Terraform configuration:
-
-```bash
-terraform apply
-```
-
-1. Optionally re-run `dd-tf dashboards download --update` to confirm the remote now matches your files.
-
-## Design choice: Datadog has a Go client
-
-I intentionally chose not to use the official Datadog Go API client for this
-tool. I previously found it can lag behind new features and may not even expose
-certain api endpoints, and sometimes strips data present in api responses -
-because it reads the api response, parses it, and generates json from that
-parsed representation. Rather than worry about that, using the REST API directly
-and persisting the raw JSON ensures confidence of avoiding such issues, with
-simpler code.
-
-## Troubleshooting
-
-* **401/403 from the API**: Check `DD_API_KEY`, `DD_APP_KEY`, and `DD_SITE`.
-* **DNS lookup errors like `api.api.datadoghq.*`**: Your `DD_SITE` includes `api.` prefix. Remove it.
-* **5xx from the API**: The API is having a bad day... struggle on or try again later.
-* **Files not where you expect**: Verify `DASHBOARDS_PATH_TEMPLATE` or your `--output` flag and remember titles/tags are sanitized.
-
-## Repository layout
-
-* `cmd/dd-tf/` – CLI entrypoint
-* `internal/commands/` – individual commands and subcommands
-* `internal/config/` – settings and environment configuration
-* `internal/datadog/` – Datadog specific (API) logic
-* `internal/http/` – HTTP client with retry logic and rate limiting
-* `internal/storage/` – file I/O and JSON writing
-* `internal/utils/` – generic string utilities
-* `data/` – default output directory for JSON files
-
-## Roadmap
-
-* Add monitors resource handling ?
-* Additional resource types (tbd)
-* Optional helpers for Terraform generation (tbd)
+- Start: [docs/README.md](docs/README.md)
+- Dashboards command: [docs/dashboards.md](docs/dashboards.md)
 
 ## License
 
 MIT – see `LICENSE`.
-
-datadog_dashboard_resource: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/dashboard
-datadog_dashboard_json_resource: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/dashboard_json

--- a/cmd/dd-tf/main.go
+++ b/cmd/dd-tf/main.go
@@ -1,16 +1,27 @@
 package main
 
 import (
+	"os"
+
 	"github.com/AD7six/dd-tf/internal/commands/dashboards"
 	"github.com/AD7six/dd-tf/internal/commands/version"
 	"github.com/spf13/cobra"
 )
 
+var verbose bool
+
 func main() {
 	root := &cobra.Command{
 		Use:   "dd-tf",
 		Short: "Datadog Terraform management CLI",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if verbose {
+				os.Setenv("DEBUG", "1")
+			}
+		},
 	}
+
+	root.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose/debug output (shows curl commands)")
 
 	root.AddCommand(dashboards.NewDashboardsCmd())
 	root.AddCommand(version.NewVersionCmd())

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,234 @@
+# dd-tf documentation
+
+dd-tf is a Datadog ⇄ Terraform helper CLI that downloads Datadog resources as
+JSON files, so you can track them in version control and use them with
+Terraform.
+
+## Why
+
+If you're managing your Datadog resources entirely in the UI you've likely
+already had the experience of looking for something (a dashboard or monitor) and
+finding it unexpectedly changed or missing. When this happens how can you see
+what changed, and restore an earlier version if necessary?
+
+The Datadog-account solution is to enable the audit trail, which works great -
+but you don't need to rely on that feature, you can also track resources in your
+own version control system.
+
+This CLI lets you pull dashboards and monitors as JSON, with the idea that you'd
+then wire them into Terraform of if desired as a git archive of account data.
+
+## What it does
+
+- Downloads Datadog dashboards and monitors using Datadog's REST API
+- Writes JSON files for each resource to a path of your choice
+
+This CLI intentionally doesn't have any update mechanism back to Datadog; the
+intent is to use Terraform as the source of truth for restoring state when
+necessary.
+
+## Install
+
+Prerequisites: Go 1.21+
+
+From source (recommended during development):
+
+```bash
+make build
+```
+
+Binary will be created at `bin/dd-tf`.
+
+Or install directly with Go:
+
+```bash
+go install github.com/AD7six/dd-tf/cmd/dd-tf@latest
+```
+
+## Configure
+
+The CLI reads environment variables and also supports a local `.env` file
+(loaded via `godotenv`).
+
+Minimum required:
+
+- `DD_API_KEY` – your Datadog API key
+- `DD_APP_KEY` – your Datadog application key
+
+Optional:
+
+- `DD_SITE` – Datadog site parameter (default: `datadoghq.com`)
+- `DATA_DIR` – base folder for data files (default: `data`)
+- `DASHBOARDS_PATH_TEMPLATE` – dashboard path pattern (default: `{DATA_DIR}/dashboards/{id}.json`)
+- `HTTP_TIMEOUT` – HTTP client timeout in seconds (default: `60`)
+
+`.env` example:
+
+```dotenv
+DD_API_KEY=your_api_key
+DD_APP_KEY=your_app_key
+# DD_SITE=datadoghq.eu # or us3.datadoghq.com, etc. 
+# DATA_DIR=/my/datadog/account/data/is/here
+# DASHBOARDS_PATH_TEMPLATE={DATA_DIR}/dashboards/{team}/{title}-{id}.json
+# HTTP_TIMEOUT=60
+```
+
+## Path templating
+
+Defaults:
+
+- Dashboards: `data/dashboards/{id}.json`
+
+Override via CLI:
+
+```bash
+dd-tf dashboards download --all --output='/somewhere/else/{id}-{title}.json'
+```
+
+Or set environment variables: `DATA_DIR`, `DASHBOARDS_PATH_TEMPLATE`
+
+Supported placeholders (rendered with Go templates):
+
+- `{DATA_DIR}`
+- `{id}`
+- `{title}` 
+- `{team}`
+- Any tag key placeholder like `{env}` or `{service}` – any tag present on the resource
+
+Notes:
+
+- Titles, names, and tag values are sanitized for safe filenames (non-alphanumerics → `-`).
+- If a placeholder is missing or empty the string `none` is used.
+
+## Usage
+
+- Dashboards command: see [docs/dashboards.md](./dashboards.md)
+
+You can always list commands via:
+
+```bash
+bin/dd-tf --help
+bin/dd-tf dashboards --help
+```
+
+## Workflows
+
+A brief overview of workflows where this tool can be helpful.
+
+### Updating terraform-managed resources
+
+This only really applies to dashboards, as their data structure is not easily
+represented via the [standard dashboard resource][datadog_dashboard_resource)
+whereas monitors and other resources are likely better suited to their non‑JSON
+Terraform representations.
+
+Anything but trivial edits to a terraform-tracked dashboard can be pretty
+painful, and even more so to create a dashboard from scratch. The typical
+process to do this is either
+
+#### _Really_ painful
+
+1. Modify [datadog_dashboard][datadog_dashboard_resource] terraform resource
+2. Look at the `terraform plan` output
+3. Hope for the best
+4. `terraform apply`, spot a mistake and return to 1.
+
+#### Slightly-less painful
+
+1. Make live edits to the dashboard via Datadog's UI
+2. Modify [datadog_dashboard][datadog_dashboard_resource] terraform resource
+3. run `terraform plan` until there are no differences reported 
+4. `terraform apply` when config matches current state
+
+#### Almost, but still painful
+
+1. Make live edits to the dashboard via Datadog's UI
+2. Modify [datadog_dashboard_json][datadog_dashboard_json_resource] terraform resource
+3. Run `terraform plan` until there are no differences reported 
+5. Run `terraform apply` (no-op)
+
+Even this permutation still has some rough edges:
+
+* The easiest way to get the json representation of a dashboard is to use
+  Configure ➡️ `Export dashboard json` 
+* 👆🏻 returns a reduced set of properties compared to the Datadog API response
+  for a dashboard
+* Even if the missing properties have no functional effect, it introduces
+  differences and commit churn unless every person updating the json uses the
+  same process.
+
+#### Edit in the UI; sync with dd-tf
+
+Where `dd-tf` comes in is to smooth out that process such that it becomes:
+
+1. Make live edits to the dashboard
+2. In the relevant terraform project, run `dd-tf dashboards download --update`
+3. `git diff` or other validation to verify the live changes are desired
+4. Run `terraform plan` with no differences reported
+5. Run `terraform apply` (no-op)
+
+This provides the best of both worlds with version-control of the contents of
+important dashboards, without a problematic process when they need to update.
+
+See the [sample Terraform project](../terraform/) for a working example that
+demonstrates this workflow.
+
+### Archiving all data
+
+Periodically run the equivalent of these commands:
+
+```
+cd /my/datadog/git/archive
+mv data olddata                 # Move previous data out the way
+dd-tf dashboards download --all # Download all dashboards
+git add data                    # Add all current data
+git commit -am "current state"
+```
+
+In this way you'll have a full archive of all your dashboards and monitors to
+refer to at any time, and then:
+
+* "My dashboard is broken!" ➡️ Find it in the archive ➡️ Restore it
+* "A monitor has been deleted!" ➡️ Find it in the archive ➡️ Restore it
+
+For resources that are already tracked by terraform this may not be necessary,
+but if there are parameterized resources (create one monitor per environment)
+this kind of archive can _still_ be useful when tooling changes are made and it
+turns out all the staging environment monitors went missing 🙃.
+
+## Design choices
+
+Datadog frequently adds new features which are not supported by the official Go
+SDK (at least, that's been my experience). This tool uses the Datadog REST API
+directly to avoid scope for missing data, and a dependency on the official SDK
+version.
+
+## Troubleshooting
+
+- 401/403 from the API: Check `DD_API_KEY`, `DD_APP_KEY`, `DD_SITE`.
+- 5xx from the API: Retry later; the API may be degraded.
+- Files not where you expect: Verify your templating flags and env vars.
+
+## Repository layout
+
+- `cmd/dd-tf/` – CLI entrypoint
+- `internal/commands/` – individual commands and subcommands
+- `internal/config/` – settings and environment configuration
+- `internal/datadog/` – Datadog specific (API) logic
+- `internal/http/` – HTTP client with retry logic and rate limiting
+- `internal/storage/` – file I/O and JSON writing
+- `internal/utils/` – generic string utilities
+- `data/` – default output directory for JSON files
+
+## Roadmap
+
+- Additional resource types (tbd)
+- Optional helpers for Terraform generation (tbd)
+
+## References
+
+- [Terraform Datadog dashboard resource][datadog_dashboard_resource]
+- [Terraform Datadog dashboard_json resource][datadog_dashboard_json_resource]
+
+[datadog_dashboard_resource]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/dashboard
+[datadog_dashboard_json_resource]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/dashboard_json

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -1,0 +1,65 @@
+# Dashboards command
+
+Download Datadog dashboards as JSON files.
+
+## Synopsis
+
+```bash
+bin/dd-tf dashboards download [flags]
+```
+
+## Flags
+
+- `--id` string: Dashboard ID(s) to download (comma-separated). The ID is visible in the Datadog URL: `https://app.datadoghq.com/dash/<id>`.
+- `--all`: Download all dashboards.
+- `--update`: Update already-downloaded dashboards by scanning existing JSON files under `{DATA_DIR}/dashboards` and re-downloading by `id`.
+- `--team` string: Filter by team (convenience for tag `team:x`).
+- `--tags` string: Comma-separated list of tags to filter dashboards.
+- `--output` string: Output path template (supports `{DATA_DIR}`, `{id}`, `{title}`, `{team}`, and any tag key placeholder like `{env}`).
+
+At least one of `--update`, `--all`, `--id`, `--team`, or `--tags` must be provided.
+
+## Examples
+
+```bash
+# Download specific dashboards by id
+bin/dd-tf dashboards download --id=abc-def-gh1,abc-def-gh2
+
+# Refresh dashboards already tracked locally
+bin/dd-tf dashboards download --update
+
+# Download all dashboards
+bin/dd-tf dashboards download --all
+
+# Download all dashboards owned by my team
+bin/dd-tf dashboards download --team=myteam
+
+# Download all dashboards, group by team and include title in filename
+bin/dd-tf dashboards download --all --output='{DATA_DIR}/dashboards/{team}/{title}-{id}.json'
+```
+
+## Path templating
+
+Default: `{DATA_DIR}/dashboards/{id}.json`
+
+Placeholders:
+
+- `{DATA_DIR}`
+- `{id}`
+- `{title}`
+- `{team}`
+- Any tag key placeholder like `{env}` or `{service}` – any tag present on the dashboard
+
+Notes:
+
+- Titles and tag values are sanitized (non-alphanumerics → `-`)
+- Missing values render as `none`
+
+## Environment
+
+- `DATA_DIR` – base folder for data files (default: `data`)
+- `DASHBOARDS_PATH_TEMPLATE` – dashboard path pattern (default: `{DATA_DIR}/dashboards/{id}.json`)
+
+## See also
+
+- General docs: [docs/README.md](./README.md)

--- a/internal/commands/dashboards/download.go
+++ b/internal/commands/dashboards/download.go
@@ -38,7 +38,7 @@ func NewDownloadCmd() *cobra.Command {
 
 	cmd.Flags().BoolVar(&allFlag, "all", false, "Download all dashboards")
 	cmd.Flags().BoolVar(&updateFlag, "update", false, "Update already-downloaded dashboards (scans existing files)")
-	cmd.Flags().StringVar(&outputPath, "output", "", "Output path template (supports {DASHBOARDS_DIR}, {id}, {title}, {team} and {any-tag}")
+	cmd.Flags().StringVar(&outputPath, "output", "", "Output path template (supports {DATA_DIR}, {id}, {title}, {team} and {any-tag}")
 	cmd.Flags().StringVar(&team, "team", "", "Team name (convenience for tag 'team:x')")
 	cmd.Flags().StringVar(&tags, "tags", "", "Comma-separated list of tags to filter dashboards")
 	cmd.Flags().StringVar(&dashboardID, "id", "", "Dashboard ID(s) to download (comma-separated)")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,14 +16,17 @@ type Settings struct {
 	APIKey                 string        // Required, Datadog API key
 	AppKey                 string        // Required, Datadog application key
 	Site                   string        // Datadog site (e.g., datadoghq.com). Used to build https://api.{Site}
-	DashboardsDir          string        // Where dashboard JSON files are stored
-	DashboardsPathTemplate string        // Path template for dashboard full path, defaults to "{DASHBOARDS_DIR}/{id}.json"
+	DataDir                string        // Base data directory for all resources (default: data/)
+	DashboardsPathTemplate string        // Path template for dashboard full path, defaults to "{DATA_DIR}/dashboards/{id}.json"
+	MonitorsPathTemplate   string        // Path template for monitor full path, defaults to "{DATA_DIR}/monitors/{id}.json"
 	HTTPTimeout            time.Duration // HTTP client timeout, defaults to 60 seconds
+	HTTPMaxBodySize        int64         // Maximum allowed API response body size in bytes, defaults to 10MB
+	PageSize               int           // Number of results per page for list endpoints, defaults to 1000
 }
 
 // LoadSettings loads configuration from environment variables and optional .env file.
 // Required environment variables: DD_API_KEY, DD_APP_KEY.
-// Optional variables: DD_SITE, DASHBOARDS_DIR, DASHBOARDS_PATH_TEMPLATE, HTTP_TIMEOUT.
+// Optional variables: DD_SITE, DATA_DIR, DASHBOARDS_PATH_TEMPLATE, MONITORS_PATH_TEMPLATE, HTTP_TIMEOUT, HTTP_MAX_BODY_SIZE, PAGE_SIZE.
 func LoadSettings() (*Settings, error) {
 	// If .env exists, try to load it
 	if _, err := os.Stat(".env"); err == nil {
@@ -43,24 +46,30 @@ func LoadSettings() (*Settings, error) {
 	}
 
 	site := getEnv("DD_SITE", "datadoghq.com")
-	// Normalize common misconfigurations: allow users to set DD_SITE with or without a leading "api.".
-	// We always build URLs as https://api.{Site}, so strip any leading "api." to avoid api.api.*.
 	site = strings.TrimSpace(strings.ToLower(site))
-	site = strings.TrimPrefix(site, "api.")
+	if strings.HasPrefix(site, "api.") {
+		fmt.Fprintf(os.Stderr, "Warning: DD_SITE value \"%s\" should not have prefix 'api.', removing\n", site)
+		site = strings.TrimPrefix(site, "api.")
+	}
 
-	dashboardsDir := getEnv("DASHBOARDS_DIR", "data/dashboards")
-	dashboardsPathTemplate := getEnv("DASHBOARDS_PATH_TEMPLATE", filepath.Join(dashboardsDir, "{id}.json"))
+	dataDir := getEnv("DATA_DIR", "data")
+	dashboardsPathTemplate := getEnv("DASHBOARDS_PATH_TEMPLATE", filepath.Join(dataDir, "dashboards", "{id}.json"))
+	monitorsPathTemplate := getEnv("MONITORS_PATH_TEMPLATE", filepath.Join(dataDir, "monitors", "{id}.json"))
 
-	// Parse HTTP timeout from environment (in seconds), default to 60
 	httpTimeout := time.Duration(getEnvInt("HTTP_TIMEOUT", 60)) * time.Second
+	HTTPMaxBodySize := int64(getEnvInt("HTTP_MAX_BODY_SIZE", 10*1024*1024)) // 10MB default
+	pageSize := getEnvInt("PAGE_SIZE", 1000)
 
 	return &Settings{
 		APIKey:                 apiKey,
 		AppKey:                 appKey,
 		Site:                   site,
-		DashboardsDir:          dashboardsDir,
+		DataDir:                dataDir,
 		DashboardsPathTemplate: dashboardsPathTemplate,
+		MonitorsPathTemplate:   monitorsPathTemplate,
 		HTTPTimeout:            httpTimeout,
+		HTTPMaxBodySize:        HTTPMaxBodySize,
+		PageSize:               pageSize,
 	}, nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,7 +18,6 @@ type Settings struct {
 	Site                   string        // Datadog site (e.g., datadoghq.com). Used to build https://api.{Site}
 	DataDir                string        // Base data directory for all resources (default: data/)
 	DashboardsPathTemplate string        // Path template for dashboard full path, defaults to "{DATA_DIR}/dashboards/{id}.json"
-	MonitorsPathTemplate   string        // Path template for monitor full path, defaults to "{DATA_DIR}/monitors/{id}.json"
 	HTTPTimeout            time.Duration // HTTP client timeout, defaults to 60 seconds
 	HTTPMaxBodySize        int64         // Maximum allowed API response body size in bytes, defaults to 10MB
 	PageSize               int           // Number of results per page for list endpoints, defaults to 1000
@@ -26,7 +25,7 @@ type Settings struct {
 
 // LoadSettings loads configuration from environment variables and optional .env file.
 // Required environment variables: DD_API_KEY, DD_APP_KEY.
-// Optional variables: DD_SITE, DATA_DIR, DASHBOARDS_PATH_TEMPLATE, MONITORS_PATH_TEMPLATE, HTTP_TIMEOUT, HTTP_MAX_BODY_SIZE, PAGE_SIZE.
+// Optional variables: DD_SITE, DATA_DIR, DASHBOARDS_PATH_TEMPLATE, HTTP_TIMEOUT, HTTP_MAX_BODY_SIZE, PAGE_SIZE.
 func LoadSettings() (*Settings, error) {
 	// If .env exists, try to load it
 	if _, err := os.Stat(".env"); err == nil {
@@ -54,7 +53,6 @@ func LoadSettings() (*Settings, error) {
 
 	dataDir := getEnv("DATA_DIR", "data")
 	dashboardsPathTemplate := getEnv("DASHBOARDS_PATH_TEMPLATE", filepath.Join(dataDir, "dashboards", "{id}.json"))
-	monitorsPathTemplate := getEnv("MONITORS_PATH_TEMPLATE", filepath.Join(dataDir, "monitors", "{id}.json"))
 
 	httpTimeout := time.Duration(getEnvInt("HTTP_TIMEOUT", 60)) * time.Second
 	HTTPMaxBodySize := int64(getEnvInt("HTTP_MAX_BODY_SIZE", 10*1024*1024)) // 10MB default
@@ -66,7 +64,6 @@ func LoadSettings() (*Settings, error) {
 		Site:                   site,
 		DataDir:                dataDir,
 		DashboardsPathTemplate: dashboardsPathTemplate,
-		MonitorsPathTemplate:   monitorsPathTemplate,
 		HTTPTimeout:            httpTimeout,
 		HTTPMaxBodySize:        HTTPMaxBodySize,
 		PageSize:               pageSize,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -342,7 +342,7 @@ func TestLoadSettings(t *testing.T) {
 		os.Unsetenv("DD_API_KEY")
 		os.Unsetenv("DD_APP_KEY")
 		os.Unsetenv("DD_SITE")
-		os.Unsetenv("DASHBOARDS_DIR")
+		os.Unsetenv("DATA_DIR")
 		os.Unsetenv("DASHBOARDS_PATH_TEMPLATE")
 		os.Unsetenv("HTTP_TIMEOUT")
 	}
@@ -383,9 +383,11 @@ func TestLoadSettings(t *testing.T) {
 			APIKey:                 "test_api_key",
 			AppKey:                 "test_app_key",
 			Site:                   "datadoghq.com",
-			DashboardsDir:          "data/dashboards",
+			DataDir:                "data",
 			DashboardsPathTemplate: "data/dashboards/{id}.json",
+			MonitorsPathTemplate:   "data/monitors/{id}.json",
 			HTTPTimeout:            60 * time.Second,
+			HTTPMaxBodySize:        10 * 1024 * 1024, // 10MB
 		}
 
 		if !reflect.DeepEqual(got, want) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -385,9 +385,9 @@ func TestLoadSettings(t *testing.T) {
 			Site:                   "datadoghq.com",
 			DataDir:                "data",
 			DashboardsPathTemplate: "data/dashboards/{id}.json",
-			MonitorsPathTemplate:   "data/monitors/{id}.json",
 			HTTPTimeout:            60 * time.Second,
 			HTTPMaxBodySize:        10 * 1024 * 1024, // 10MB
+			PageSize:               1000,
 		}
 
 		if !reflect.DeepEqual(got, want) {

--- a/internal/datadog/dashboards/client_test.go
+++ b/internal/datadog/dashboards/client_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestComputeDashboardPath_MissingFields(t *testing.T) {
 	settings := &config.Settings{
-		DashboardsDir:          "/test/dashboards",
-		DashboardsPathTemplate: "{DASHBOARDS_DIR}/{id}-{title}.json",
+		DataDir:                "/test/data",
+		DashboardsPathTemplate: "{DATA_DIR}/dashboards/{id}-{title}.json",
 	}
 
 	t.Run("missing id field", func(t *testing.T) {
@@ -126,7 +126,7 @@ func TestComputeDashboardPath_MissingFields(t *testing.T) {
 
 		path := ComputeDashboardPath(settings, dashboard, "")
 
-		expected := filepath.Join("/test/dashboards", "valid-123-My-Dashboard.json")
+		expected := filepath.Join("/test/data/dashboards", "valid-123-My-Dashboard.json")
 		if path != expected {
 			t.Errorf("Expected path %s, got: %s", expected, path)
 		}
@@ -135,8 +135,8 @@ func TestComputeDashboardPath_MissingFields(t *testing.T) {
 
 func TestComputeDashboardPath_WithTags(t *testing.T) {
 	settings := &config.Settings{
-		DashboardsDir:          "/test/dashboards",
-		DashboardsPathTemplate: "{DASHBOARDS_DIR}/{team}/{title}-{id}.json",
+		DataDir:                "/test/data",
+		DashboardsPathTemplate: "{DATA_DIR}/dashboards/{team}/{title}-{id}.json",
 	}
 
 	t.Run("with valid tags", func(t *testing.T) {
@@ -174,8 +174,8 @@ func TestComputeDashboardPath_WithTags(t *testing.T) {
 
 func TestComputeDashboardPath_WithOutputOverride(t *testing.T) {
 	settings := &config.Settings{
-		DashboardsDir:          "/test/dashboards",
-		DashboardsPathTemplate: "{DASHBOARDS_DIR}/{id}.json", // Default pattern
+		DataDir:                "/test/data",
+		DashboardsPathTemplate: "{DATA_DIR}/dashboards/{id}.json", // Default pattern
 	}
 
 	dashboard := map[string]any{
@@ -198,7 +198,7 @@ func TestComputeDashboardPath_WithOutputOverride(t *testing.T) {
 	t.Run("uses default pattern when override is empty", func(t *testing.T) {
 		path := ComputeDashboardPath(settings, dashboard, "")
 
-		expected := filepath.Join("/test/dashboards", "override-123.json")
+		expected := filepath.Join("/test/data/dashboards", "override-123.json")
 		if path != expected {
 			t.Errorf("Expected path %s, got: %s", expected, path)
 		}

--- a/internal/datadog/templating/tags.go
+++ b/internal/datadog/templating/tags.go
@@ -1,0 +1,69 @@
+package templating
+
+import (
+	"strings"
+
+	"github.com/AD7six/dd-tf/internal/storage"
+)
+
+// ExtractTagMap converts a raw tags value (typically []any or []interface{}) into a map[key]value.
+// If sanitize is true, values are sanitized via storage.SanitizeFilename.
+func ExtractTagMap(raw any, sanitize bool) map[string]string {
+	tagMap := make(map[string]string)
+	switch v := raw.(type) {
+	case []interface{}:
+		for _, t := range v {
+			if s, ok := t.(string); ok {
+				parts := strings.SplitN(s, ":", 2)
+				if len(parts) == 2 {
+					key := strings.TrimSpace(parts[0])
+					val := strings.TrimSpace(parts[1])
+					if sanitize {
+						val = storage.SanitizeFilename(val)
+					}
+					tagMap[key] = val
+				}
+			}
+		}
+	}
+	return tagMap
+}
+
+// HasAllTagsMap checks if tags contain all required filterTags (case-insensitive),
+// where filterTags are in the form key:value.
+func HasAllTagsMap(tags map[string]string, filterTags []string) bool {
+	if len(filterTags) == 0 {
+		return true
+	}
+	for _, want := range filterTags {
+		wantLower := strings.ToLower(want)
+		found := false
+		for k, v := range tags {
+			if strings.ToLower(k+":"+v) == wantLower {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// HasAllTagsSlice checks if all filterTags are present in dashboardTags (both lowercase for comparison).
+func HasAllTagsSlice(dashboardTags []string, filterTags []string) bool {
+	if len(filterTags) == 0 {
+		return true
+	}
+	set := make(map[string]struct{}, len(dashboardTags))
+	for _, t := range dashboardTags {
+		set[strings.ToLower(t)] = struct{}{}
+	}
+	for _, want := range filterTags {
+		if _, ok := set[strings.ToLower(want)]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/datadog/templating/tags_test.go
+++ b/internal/datadog/templating/tags_test.go
@@ -1,0 +1,351 @@
+package templating
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExtractTagMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      any
+		sanitize bool
+		want     map[string]string
+	}{
+		{
+			name:     "nil input",
+			raw:      nil,
+			sanitize: false,
+			want:     map[string]string{},
+		},
+		{
+			name:     "empty slice",
+			raw:      []any{},
+			sanitize: false,
+			want:     map[string]string{},
+		},
+		{
+			name: "simple tags",
+			raw: []any{
+				"team:platform",
+				"env:prod",
+				"service:api",
+			},
+			sanitize: false,
+			want: map[string]string{
+				"team":    "platform",
+				"env":     "prod",
+				"service": "api",
+			},
+		},
+		{
+			name: "tags with spaces",
+			raw: []any{
+				"team: platform ",
+				" env : prod",
+				"service:  api  ",
+			},
+			sanitize: false,
+			want: map[string]string{
+				"team":    "platform",
+				"env":     "prod",
+				"service": "api",
+			},
+		},
+		{
+			name: "tags without colons ignored",
+			raw: []any{
+				"team:platform",
+				"invalid-tag",
+				"env:prod",
+			},
+			sanitize: false,
+			want: map[string]string{
+				"team": "platform",
+				"env":  "prod",
+			},
+		},
+		{
+			name: "tags with multiple colons",
+			raw: []any{
+				"url:https://example.com:8080",
+				"team:platform",
+			},
+			sanitize: false,
+			want: map[string]string{
+				"url":  "https://example.com:8080",
+				"team": "platform",
+			},
+		},
+		{
+			name: "sanitize enabled",
+			raw: []any{
+				"team:platform Team",
+				"service:My/Service",
+			},
+			sanitize: true,
+			want: map[string]string{
+				"team":    "platform-Team",
+				"service": "My-Service",
+			},
+		},
+		{
+			name: "sanitize disabled",
+			raw: []any{
+				"team:platform Team",
+				"service:My/Service",
+			},
+			sanitize: false,
+			want: map[string]string{
+				"team":    "platform Team",
+				"service": "My/Service",
+			},
+		},
+		{
+			name: "non-string items ignored",
+			raw: []any{
+				"team:platform",
+				123,
+				true,
+				"env:prod",
+			},
+			sanitize: false,
+			want: map[string]string{
+				"team": "platform",
+				"env":  "prod",
+			},
+		},
+		{
+			name:     "wrong type input",
+			raw:      "not-a-slice",
+			sanitize: false,
+			want:     map[string]string{},
+		},
+		{
+			name: "duplicate keys - last wins",
+			raw: []any{
+				"team:frontend",
+				"team:platform",
+			},
+			sanitize: false,
+			want: map[string]string{
+				"team": "platform",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractTagMap(tt.raw, tt.sanitize)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ExtractTagMap(%v, %v) = %v, want %v", tt.raw, tt.sanitize, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasAllTagsMap(t *testing.T) {
+	tests := []struct {
+		name       string
+		tags       map[string]string
+		filterTags []string
+		want       bool
+	}{
+		{
+			name:       "empty filter always matches",
+			tags:       map[string]string{"team": "platform"},
+			filterTags: []string{},
+			want:       true,
+		},
+		{
+			name:       "nil filter always matches",
+			tags:       map[string]string{"team": "platform"},
+			filterTags: nil,
+			want:       true,
+		},
+		{
+			name: "exact match",
+			tags: map[string]string{
+				"team": "platform",
+				"env":  "prod",
+			},
+			filterTags: []string{"team:platform"},
+			want:       true,
+		},
+		{
+			name: "all filters match",
+			tags: map[string]string{
+				"team":    "platform",
+				"env":     "prod",
+				"service": "api",
+			},
+			filterTags: []string{"team:platform", "env:prod"},
+			want:       true,
+		},
+		{
+			name: "one filter missing",
+			tags: map[string]string{
+				"team": "platform",
+				"env":  "prod",
+			},
+			filterTags: []string{"team:platform", "service:api"},
+			want:       false,
+		},
+		{
+			name:       "empty tags, non-empty filter",
+			tags:       map[string]string{},
+			filterTags: []string{"team:platform"},
+			want:       false,
+		},
+		{
+			name: "case insensitive match",
+			tags: map[string]string{
+				"team": "platform",
+				"env":  "PROD",
+			},
+			filterTags: []string{"TEAM:platform", "ENV:prod"},
+			want:       true,
+		},
+		{
+			name: "case insensitive key and value",
+			tags: map[string]string{
+				"Team": "platform",
+			},
+			filterTags: []string{"team:platform"},
+			want:       true,
+		},
+		{
+			name: "partial match not enough",
+			tags: map[string]string{
+				"team": "platform",
+			},
+			filterTags: []string{"team:platform", "team:frontend"},
+			want:       false,
+		},
+		{
+			name: "multiple filters all present",
+			tags: map[string]string{
+				"team":     "platform",
+				"env":      "prod",
+				"service":  "api",
+				"priority": "1",
+			},
+			filterTags: []string{"team:platform", "env:prod", "priority:1"},
+			want:       true,
+		},
+		{
+			name: "wrong value",
+			tags: map[string]string{
+				"team": "platform",
+			},
+			filterTags: []string{"team:frontend"},
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HasAllTagsMap(tt.tags, tt.filterTags)
+			if got != tt.want {
+				t.Errorf("HasAllTagsMap(%v, %v) = %v, want %v", tt.tags, tt.filterTags, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasAllTagsSlice(t *testing.T) {
+	tests := []struct {
+		name          string
+		dashboardTags []string
+		filterTags    []string
+		want          bool
+	}{
+		{
+			name:          "empty filter always matches",
+			dashboardTags: []string{"team:platform"},
+			filterTags:    []string{},
+			want:          true,
+		},
+		{
+			name:          "nil filter always matches",
+			dashboardTags: []string{"team:platform"},
+			filterTags:    nil,
+			want:          true,
+		},
+		{
+			name:          "exact match",
+			dashboardTags: []string{"team:platform", "env:prod"},
+			filterTags:    []string{"team:platform"},
+			want:          true,
+		},
+		{
+			name:          "all filters present",
+			dashboardTags: []string{"team:platform", "env:prod", "service:api"},
+			filterTags:    []string{"team:platform", "env:prod"},
+			want:          true,
+		},
+		{
+			name:          "one filter missing",
+			dashboardTags: []string{"team:platform", "env:prod"},
+			filterTags:    []string{"team:platform", "service:api"},
+			want:          false,
+		},
+		{
+			name:          "empty dashboard tags, non-empty filter",
+			dashboardTags: []string{},
+			filterTags:    []string{"team:platform"},
+			want:          false,
+		},
+		{
+			name:          "nil dashboard tags, non-empty filter",
+			dashboardTags: nil,
+			filterTags:    []string{"team:platform"},
+			want:          false,
+		},
+		{
+			name:          "case insensitive match",
+			dashboardTags: []string{"Team:platform", "ENV:PROD"},
+			filterTags:    []string{"team:platform", "env:prod"},
+			want:          true,
+		},
+		{
+			name:          "mixed case",
+			dashboardTags: []string{"TEAM:platform", "env:PROD"},
+			filterTags:    []string{"team:platform", "ENV:prod"},
+			want:          true,
+		},
+		{
+			name:          "duplicate tags in dashboard",
+			dashboardTags: []string{"team:platform", "team:platform", "env:prod"},
+			filterTags:    []string{"team:platform"},
+			want:          true,
+		},
+		{
+			name:          "all filters match with extras",
+			dashboardTags: []string{"team:platform", "env:prod", "service:api", "priority:1"},
+			filterTags:    []string{"team:platform", "priority:1"},
+			want:          true,
+		},
+		{
+			name:          "partial tag value match fails",
+			dashboardTags: []string{"team:platform"},
+			filterTags:    []string{"team:back"},
+			want:          false,
+		},
+		{
+			name:          "substring not a match",
+			dashboardTags: []string{"team:platform-service"},
+			filterTags:    []string{"team:platform"},
+			want:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HasAllTagsSlice(tt.dashboardTags, tt.filterTags)
+			if got != tt.want {
+				t.Errorf("HasAllTagsSlice(%v, %v) = %v, want %v", tt.dashboardTags, tt.filterTags, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/datadog/templating/templating_test.go
+++ b/internal/datadog/templating/templating_test.go
@@ -1,0 +1,321 @@
+package templating
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTranslatePlaceholders(t *testing.T) {
+	tests := []struct {
+		name     string
+		pattern  string
+		builtins map[string]string
+		envVars  map[string]string // environment variables to set for the test
+		want     string
+	}{
+		{
+			name:     "no placeholders",
+			pattern:  "static/path/file.json",
+			builtins: map[string]string{},
+			want:     "static/path/file.json",
+		},
+		{
+			name:    "builtin placeholder",
+			pattern: "{DATA_DIR}/dashboards/{id}.json",
+			builtins: map[string]string{
+				"{DATA_DIR}": "{{.DataDir}}",
+				"{id}":       "{{.ID}}",
+			},
+			want: "{{.DataDir}}/dashboards/{{.ID}}.json",
+		},
+		{
+			name:    "tag placeholder",
+			pattern: "{DATA_DIR}/dashboards/{team}/{id}.json",
+			builtins: map[string]string{
+				"{DATA_DIR}": "{{.DataDir}}",
+				"{id}":       "{{.ID}}",
+			},
+			want: "{{.DataDir}}/dashboards/{{.Tags.team}}/{{.ID}}.json",
+		},
+		{
+			name:    "multiple tag placeholders",
+			pattern: "{team}/{env}/{service}/{id}.json",
+			builtins: map[string]string{
+				"{id}": "{{.ID}}",
+			},
+			want: "{{.Tags.team}}/{{.Tags.env}}/{{.Tags.service}}/{{.ID}}.json",
+		},
+		{
+			name:     "only tag placeholders",
+			pattern:  "{team}/{priority}/{name}.json",
+			builtins: map[string]string{},
+			want:     "{{.Tags.team}}/{{.Tags.priority}}/{{.Tags.name}}.json",
+		},
+		{
+			name:    "mixed case and special chars",
+			pattern: "{DATA_DIR}/{Team_Name}/{id-123}.json",
+			builtins: map[string]string{
+				"{DATA_DIR}": "{{.DataDir}}",
+			},
+			want: "{{.DataDir}}/{{.Tags.Team_Name}}/{{.Tags.id-123}}.json",
+		},
+		{
+			name:    "all builtins matched",
+			pattern: "{DATA_DIR}/{id}/{title}",
+			builtins: map[string]string{
+				"{DATA_DIR}": "{{.DataDir}}",
+				"{id}":       "{{.ID}}",
+				"{title}":    "{{.Title}}",
+			},
+			want: "{{.DataDir}}/{{.ID}}/{{.Title}}",
+		},
+		{
+			name:    "duplicate placeholders",
+			pattern: "{team}/{team}/{id}",
+			builtins: map[string]string{
+				"{id}": "{{.ID}}",
+			},
+			want: "{{.Tags.team}}/{{.Tags.team}}/{{.ID}}",
+		},
+		{
+			name:     "empty pattern",
+			pattern:  "",
+			builtins: map[string]string{},
+			want:     "",
+		},
+		{
+			name:    "environment variable placeholder",
+			pattern: "{MY_CUSTOM_PATH}/dashboards/{id}.json",
+			builtins: map[string]string{
+				"{id}": "{{.ID}}",
+			},
+			envVars: map[string]string{
+				"MY_CUSTOM_PATH": "/var/data",
+			},
+			want: "/var/data/dashboards/{{.ID}}.json",
+		},
+		{
+			name:    "environment variable not set falls back to tag",
+			pattern: "{MISSING_VAR}/dashboards/{id}.json",
+			builtins: map[string]string{
+				"{id}": "{{.ID}}",
+			},
+			want: "{{.Tags.MISSING_VAR}}/dashboards/{{.ID}}.json",
+		},
+		{
+			name:    "env var replaced before builtin - builtin doesn't match anymore",
+			pattern: "{DATA_DIR}/dashboards/{id}.json",
+			builtins: map[string]string{
+				"{DATA_DIR}": "{{.DataDir}}",
+				"{id}":       "{{.ID}}",
+			},
+			envVars: map[string]string{
+				"DATA_DIR": "/var/data",
+			},
+			want: "/var/data/dashboards/{{.ID}}.json",
+		},
+		{
+			name:    "builtin works when env var not set",
+			pattern: "{DATA_DIR}/dashboards/{id}.json",
+			builtins: map[string]string{
+				"{DATA_DIR}": "{{.DataDir}}",
+				"{id}":       "{{.ID}}",
+			},
+			want: "{{.DataDir}}/dashboards/{{.ID}}.json",
+		},
+		{
+			name:    "multiple env vars",
+			pattern: "{BASE_DIR}/{ENVIRONMENT}/{id}.json",
+			builtins: map[string]string{
+				"{id}": "{{.ID}}",
+			},
+			envVars: map[string]string{
+				"BASE_DIR":    "/opt/data",
+				"ENVIRONMENT": "production",
+			},
+			want: "/opt/data/production/{{.ID}}.json",
+		},
+		{
+			name:    "lowercase not treated as env var",
+			pattern: "{my_var}/{id}.json",
+			builtins: map[string]string{
+				"{id}": "{{.ID}}",
+			},
+			envVars: map[string]string{
+				"my_var": "/should/not/be/used",
+			},
+			want: "{{.Tags.my_var}}/{{.ID}}.json",
+		},
+		{
+			name:    "mixed case not treated as env var",
+			pattern: "{My_Var}/{id}.json",
+			builtins: map[string]string{
+				"{id}": "{{.ID}}",
+			},
+			envVars: map[string]string{
+				"My_Var": "/should/not/be/used",
+			},
+			want: "{{.Tags.My_Var}}/{{.ID}}.json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up environment variables for this test
+			for k, v := range tt.envVars {
+				os.Setenv(k, v)
+				defer os.Unsetenv(k)
+			}
+
+			got := TranslatePlaceholders(tt.pattern, tt.builtins)
+			if got != tt.want {
+				t.Errorf("TranslatePlaceholders(%q, %v) = %q, want %q", tt.pattern, tt.builtins, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractStaticPrefix(t *testing.T) {
+	tests := []struct {
+		name         string
+		pathTemplate string
+		envVars      map[string]string // environment variables to set for the test
+		want         string
+	}{
+		{
+			name:         "simple template with placeholder",
+			pathTemplate: "data/dashboards/{id}.json",
+			want:         "data/dashboards",
+		},
+		{
+			name:         "template with DATA_DIR placeholder first - no env var",
+			pathTemplate: "{DATA_DIR}/dashboards/{id}.json",
+			want:         "",
+		},
+		{
+			name:         "template with DATA_DIR placeholder first - with env var",
+			pathTemplate: "{DATA_DIR}/dashboards/{id}.json",
+			envVars: map[string]string{
+				"DATA_DIR": "/opt/data",
+			},
+			want: "/opt/data/dashboards",
+		},
+		{
+			name:         "template with multiple placeholders",
+			pathTemplate: "data/dashboards/{team}/{id}.json",
+			want:         "data/dashboards",
+		},
+		{
+			name:         "no placeholders - file path",
+			pathTemplate: "data/dashboards/static.json",
+			want:         "data/dashboards",
+		},
+		{
+			name:         "no placeholders - directory",
+			pathTemplate: "data/dashboards/",
+			want:         "data/dashboards",
+		},
+		{
+			name:         "absolute path with placeholder",
+			pathTemplate: "/var/data/dashboards/{id}.json",
+			want:         "/var/data/dashboards",
+		},
+		{
+			name:         "placeholder at start",
+			pathTemplate: "{id}/dashboard.json",
+			want:         "",
+		},
+		{
+			name:         "empty template",
+			pathTemplate: "",
+			want:         "",
+		},
+		{
+			name:         "complex nested path",
+			pathTemplate: "/home/user/data/dashboards/{team}/{env}/{id}.json",
+			want:         "/home/user/data/dashboards",
+		},
+		{
+			name:         "Windows-style path",
+			pathTemplate: filepath.Join("C:", "data", "dashboards", "{id}.json"),
+			want:         filepath.Join("C:", "data", "dashboards"),
+		},
+		{
+			name:         "relative path with placeholder",
+			pathTemplate: "./data/{id}.json",
+			want:         "./data",
+		},
+		{
+			name:         "just filename with placeholder",
+			pathTemplate: "{id}.json",
+			want:         "",
+		},
+		{
+			name:         "env var at start expands to static prefix",
+			pathTemplate: "{MY_BASE_DIR}/dashboards/{id}.json",
+			envVars: map[string]string{
+				"MY_BASE_DIR": "/opt/data",
+			},
+			want: "/opt/data/dashboards",
+		},
+		{
+			name:         "env var in middle expands",
+			pathTemplate: "/var/{MY_SUBDIR}/dashboards/{id}.json",
+			envVars: map[string]string{
+				"MY_SUBDIR": "custom",
+			},
+			want: "/var/custom/dashboards",
+		},
+		{
+			name:         "multiple env vars expand",
+			pathTemplate: "{BASE_DIR}/{ENVIRONMENT}/dashboards/{id}.json",
+			envVars: map[string]string{
+				"BASE_DIR":    "/opt/app",
+				"ENVIRONMENT": "production",
+			},
+			want: "/opt/app/production/dashboards",
+		},
+		{
+			name:         "unset env var not expanded - no static prefix",
+			pathTemplate: "{MISSING_VAR}/dashboards/{id}.json",
+			want:         "",
+		},
+		{
+			name:         "unset env var in middle - stops at first placeholder",
+			pathTemplate: "/var/{MISSING_VAR}/dashboards/{id}.json",
+			want:         "/var",
+		},
+		{
+			name:         "lowercase placeholder not treated as env var",
+			pathTemplate: "{my_var}/dashboards/{id}.json",
+			envVars: map[string]string{
+				"my_var": "/should/not/expand",
+			},
+			want: "",
+		},
+		{
+			name:         "env var fully expands template with no other placeholders",
+			pathTemplate: "{FULL_PATH}",
+			envVars: map[string]string{
+				"FULL_PATH": "/complete/path/to/file.json",
+			},
+			want: "/complete/path/to",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up environment variables for this test
+			for k, v := range tt.envVars {
+				os.Setenv(k, v)
+				defer os.Unsetenv(k)
+			}
+
+			got := ExtractStaticPrefix(tt.pathTemplate)
+			if got != tt.want {
+				t.Errorf("ExtractStaticPrefix(%q) = %q, want %q", tt.pathTemplate, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Extract the ground work from #2 to keep that PR focussed.

* Add launch command, to make debugging easier
* Add a verbose flag - use it to log equivalent curl requests
* Restructure docs
* Minimal tweaks to config, to not be dashboard-specific
* Add pagination handling to the dashbaords endpoint, as that was missing
* Update http class to use a sleeper interface - so tests don't have to wait in real time when testing anything that involves a delay
* Extract what will become common templating logic